### PR TITLE
[codex] add github hybrid agent automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,20 @@
+name: Agent task
+description: Request GitHub-hybrid planning/build/review automation for a personal engineering task
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should the agent accomplish?
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Non-goals, boundaries, or required approaches
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: Exact commands or checks the build stage should run

--- a/.github/scripts/agent-build.sh
+++ b/.github/scripts/agent-build.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source .github/scripts/agent-lib.sh
+
+require_env REPO
+require_env ISSUE_NUMBER
+require_cmd gh
+require_cmd jq
+require_cmd codex
+require_cmd git
+
+RUN_DIR="$(ensure_run_dir "$ISSUE_NUMBER")"
+PLAN_FILE="$RUN_DIR/Plan.json"
+BUILD_FILE="$RUN_DIR/Build.md"
+COMMENT_FILE="$RUN_DIR/build-comment.md"
+
+issue_json > "$RUN_DIR/issue.json"
+
+test -f "$PLAN_FILE" || {
+  echo "::error::Missing plan file: $PLAN_FILE" >&2
+  exit 1
+}
+
+has_label "agent:build-ready" || {
+  echo "::error::Issue must carry agent:build-ready before build" >&2
+  exit 1
+}
+
+SLUG="$(jq -r '.title // "task"' "$RUN_DIR/issue.json" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')"
+BRANCH="agent/${ISSUE_NUMBER}-${SLUG}"
+
+git checkout -B "$BRANCH"
+write_status "build" "running" "Executing approved plan with Codex"
+
+EXECUTION_BRIEF="$(jq -r '.execution_brief // .summary // "Implement the approved plan."' "$PLAN_FILE")"
+codex exec "$EXECUTION_BRIEF"
+
+VERIFY_CMDS="$(jq -r '.verification[]?' "$PLAN_FILE")"
+if [ -z "$VERIFY_CMDS" ]; then
+  echo "::error::Plan.json must provide at least one verification command" >&2
+  exit 1
+fi
+
+printf '# Build\n\n' > "$BUILD_FILE"
+while IFS= read -r cmd; do
+  [ -n "$cmd" ] || continue
+  printf -- '- `%s`\n' "$cmd" >> "$BUILD_FILE"
+  bash -lc "$cmd"
+done <<EOF
+$VERIFY_CMDS
+EOF
+
+if [ -n "$(git status --short)" ]; then
+  git add -A
+  git commit -m "feat: implement issue #$ISSUE_NUMBER plan"
+  git push -u origin "$BRANCH"
+fi
+
+PR_URL="$(
+  gh pr view "$BRANCH" --repo "$REPO" --json url 2>/dev/null | jq -r '.url // empty' || true
+)"
+if [ -z "$PR_URL" ]; then
+  PR_URL="$(gh pr create --repo "$REPO" --title "Agent build: issue #$ISSUE_NUMBER" --body "Closes #$ISSUE_NUMBER" --head "$BRANCH" --base main)"
+fi
+
+printf 'Build complete.\n\nPR: %s\n\nReview the PR on GitHub, then add the `agent:review` label to the PR when you want the bounded review pass to run.\n' "$PR_URL" > "$COMMENT_FILE"
+post_issue_comment "$COMMENT_FILE"
+gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "agent:build" --remove-label "agent:build-ready"
+write_status "build" "completed" "Build completed and PR created or updated"

--- a/.github/scripts/agent-lib.sh
+++ b/.github/scripts/agent-lib.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "::error::Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "::error::Missing required environment variable: $name" >&2
+    exit 1
+  fi
+}
+
+issue_run_dir() {
+  local issue="$1"
+  printf 'ai/runs/%s\n' "$issue"
+}
+
+ensure_run_dir() {
+  local dir
+  dir="$(issue_run_dir "$1")"
+  mkdir -p "$dir"
+  printf '%s\n' "$dir"
+}
+
+status_file() {
+  printf '%s/Status.json\n' "$(issue_run_dir "$1")"
+}
+
+issue_json() {
+  gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json number,title,body,labels,url
+}
+
+has_label() {
+  local label="$1"
+  issue_json | jq -e --arg label "$label" '.labels | map(.name) | index($label) != null' >/dev/null
+}
+
+replace_label() {
+  local remove_label="$1"
+  local add_label="$2"
+  gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "$remove_label" --add-label "$add_label"
+}
+
+post_issue_comment() {
+  local body_file="$1"
+  gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file "$body_file"
+}
+
+post_pr_comment() {
+  local pr_number="$1"
+  local body_file="$2"
+  gh pr comment "$pr_number" --repo "$REPO" --body-file "$body_file"
+}
+
+linked_issue_from_pr() {
+  local pr_number="$1"
+  gh pr view "$pr_number" --repo "$REPO" --json body --jq '.body' \
+    | sed -nE 's/.*Closes #([0-9]+).*/\1/p' \
+    | head -n1
+}
+
+write_status() {
+  local phase="$1"
+  local state="$2"
+  local message="$3"
+
+  jq -n \
+    --arg issue "$ISSUE_NUMBER" \
+    --arg phase "$phase" \
+    --arg state "$state" \
+    --arg message "$message" \
+    --arg updated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{
+      issue: $issue,
+      phase: $phase,
+      state: $state,
+      message: $message,
+      updated_at: $updated_at
+    }' > "$(status_file "$ISSUE_NUMBER")"
+}

--- a/.github/scripts/agent-plan.sh
+++ b/.github/scripts/agent-plan.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source .github/scripts/agent-lib.sh
+
+require_env REPO
+require_env ISSUE_NUMBER
+require_cmd gh
+require_cmd jq
+require_cmd claude
+
+RUN_DIR="$(ensure_run_dir "$ISSUE_NUMBER")"
+GOAL_FILE="$RUN_DIR/Goal.md"
+SPEC_FILE="$RUN_DIR/Spec.md"
+PLAN_FILE="$RUN_DIR/Plan.json"
+COMMENT_FILE="$RUN_DIR/plan-comment.md"
+PROMPT_FILE="$RUN_DIR/plan-prompt.md"
+
+issue_json > "$RUN_DIR/issue.json"
+
+jq -r '"# Goal\n\n## Issue #\(.number): \(.title)\n\n\(.body)\n"' "$RUN_DIR/issue.json" > "$GOAL_FILE"
+
+cat > "$PROMPT_FILE" <<'EOF'
+Read the goal and return JSON with exactly these top-level keys:
+- `spec_markdown`: markdown design/spec text
+- `plan_json`: object with `summary`, `execution_brief`, and `verification` array
+- `summary_markdown`: short issue comment summary
+EOF
+cat "$GOAL_FILE" >> "$PROMPT_FILE"
+
+write_status "plan" "running" "Generating plan artifacts with Claude"
+claude -p "$(cat "$PROMPT_FILE")" --output-format json > "$RUN_DIR/claude-plan.json"
+
+jq -r '.spec_markdown // .result.spec_markdown' "$RUN_DIR/claude-plan.json" > "$SPEC_FILE"
+jq '.plan_json // .result.plan_json' "$RUN_DIR/claude-plan.json" > "$PLAN_FILE"
+jq -r '.summary_markdown // .result.summary_markdown // "Plan generated."' "$RUN_DIR/claude-plan.json" > "$COMMENT_FILE"
+
+cat >> "$COMMENT_FILE" <<EOF
+
+- Spec: \`ai/runs/$ISSUE_NUMBER/Spec.md\`
+- Plan: \`ai/runs/$ISSUE_NUMBER/Plan.json\`
+- Next step: review the plan, then add the \`agent:build\` label to execute it.
+EOF
+
+post_issue_comment "$COMMENT_FILE"
+replace_label "agent:plan" "agent:build-ready"
+write_status "plan" "completed" "Plan artifacts generated"

--- a/.github/scripts/agent-review.sh
+++ b/.github/scripts/agent-review.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source .github/scripts/agent-lib.sh
+
+require_env REPO
+require_env PR_NUMBER
+require_cmd gh
+require_cmd claude
+
+ISSUE_NUMBER="$(linked_issue_from_pr "$PR_NUMBER")"
+[ -n "$ISSUE_NUMBER" ] || {
+  echo "::error::Unable to resolve linked issue from PR body" >&2
+  exit 1
+}
+
+RUN_DIR="$(ensure_run_dir "$ISSUE_NUMBER")"
+REVIEW_FILE="$RUN_DIR/Review.md"
+
+gh pr view "$PR_NUMBER" --repo "$REPO" --json number,title,body,files > "$RUN_DIR/pr.json"
+gh pr diff "$PR_NUMBER" --repo "$REPO" > "$RUN_DIR/diff.patch"
+
+write_status "review" "running" "Running bounded review"
+claude -p "Review the diff in ai/runs/$ISSUE_NUMBER/diff.patch for bugs, regressions, missing verification, and overreach. Return concise markdown." > "$REVIEW_FILE"
+post_pr_comment "$PR_NUMBER" "$REVIEW_FILE"
+
+if grep -qi "no findings" "$REVIEW_FILE"; then
+  gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "agent:build" --remove-label "agent:blocked" --add-label "agent:done"
+  write_status "review" "completed" "Review passed"
+else
+  gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "agent:done" --add-label "agent:blocked"
+  write_status "review" "blocked" "Review found issues"
+fi

--- a/.github/scripts/test-agent-automation.sh
+++ b/.github/scripts/test-agent-automation.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+if [ "${1:-}" = "--verify-stub" ]; then
+  exit 0
+fi
+
+cleanup() {
+  rm -rf "$TMPDIR_ROOT"
+  rm -rf "$ROOT_DIR/ai/runs/42"
+}
+trap cleanup EXIT
+
+TEST_TMPDIR="$TMPDIR_ROOT/run"
+STUB_DIR="$TMPDIR_ROOT/bin"
+mkdir -p "$TEST_TMPDIR" "$STUB_DIR"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file() {
+  [ -f "$1" ] || fail "Expected file to exist: $1"
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  grep -q "$pattern" "$file" || fail "Expected '$pattern' in $file"
+}
+
+cat > "$STUB_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$AGENT_TEST_TMPDIR/gh.log"
+
+case "$1 $2" in
+  "issue view")
+    cat "$AGENT_TEST_TMPDIR/issue-view.json"
+    ;;
+  "issue comment")
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--body-file" ]; then
+        shift
+        cp "$1" "$AGENT_TEST_TMPDIR/last-issue-comment.md"
+      fi
+      shift
+    done
+    ;;
+  "issue edit")
+    ;;
+  "pr view")
+    if printf '%s' "$*" | grep -q -- '--json body'; then
+      printf 'Closes #42\n'
+    else
+      cat "$AGENT_TEST_TMPDIR/pr-view.json"
+    fi
+    ;;
+  "pr diff")
+    printf 'diff --git a/a b/a\n'
+    ;;
+  "pr comment")
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--body-file" ]; then
+        shift
+        cp "$1" "$AGENT_TEST_TMPDIR/last-pr-comment.md"
+      fi
+      shift
+    done
+    ;;
+  "pr create")
+    printf 'https://github.com/example/repo/pull/99\n'
+    ;;
+  *)
+    printf 'Unhandled gh invocation: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$STUB_DIR/gh"
+
+cat > "$STUB_DIR/claude" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if printf '%s' "$*" | grep -q -- '--output-format json'; then
+  cat <<'JSON'
+{"spec_markdown":"# Spec\n","plan_json":{"summary":"summary","execution_brief":"Implement it","verification":["bash .github/scripts/test-agent-automation.sh --verify-stub"]},"summary_markdown":"Plan generated."}
+JSON
+else
+  printf 'No findings.\n'
+fi
+EOF
+chmod +x "$STUB_DIR/claude"
+
+cat > "$STUB_DIR/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$AGENT_TEST_TMPDIR/codex.log"
+exit 0
+EOF
+chmod +x "$STUB_DIR/codex"
+
+cat > "$STUB_DIR/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$AGENT_TEST_TMPDIR/git.log"
+case "${1:-}" in
+  status)
+    ;;
+  *)
+    ;;
+esac
+EOF
+chmod +x "$STUB_DIR/git"
+
+cat > "$TEST_TMPDIR/issue-view.json" <<'JSON'
+{"number":42,"title":"Test issue","body":"Do the thing","labels":[{"name":"agent:build-ready"}],"url":"https://github.com/example/repo/issues/42"}
+JSON
+
+cat > "$TEST_TMPDIR/pr-view.json" <<'JSON'
+{"number":99,"title":"Agent build: issue #42","body":"Closes #42","files":[]}
+JSON
+
+export AGENT_TEST_TMPDIR="$TEST_TMPDIR"
+export REPO="example/repo"
+export ISSUE_NUMBER="42"
+export PR_NUMBER="99"
+export GH_TOKEN="test-token"
+export PATH="$STUB_DIR:$PATH"
+
+cd "$ROOT_DIR"
+
+bash .github/scripts/agent-plan.sh
+assert_file "$ROOT_DIR/ai/runs/42/Goal.md"
+assert_file "$ROOT_DIR/ai/runs/42/Spec.md"
+assert_file "$ROOT_DIR/ai/runs/42/Plan.json"
+assert_contains "$TEST_TMPDIR/last-issue-comment.md" "Plan generated."
+
+bash .github/scripts/agent-build.sh
+assert_file "$ROOT_DIR/ai/runs/42/Build.md"
+assert_contains "$TEST_TMPDIR/last-issue-comment.md" "Build complete."
+
+bash .github/scripts/agent-review.sh
+assert_file "$ROOT_DIR/ai/runs/42/Review.md"
+assert_contains "$TEST_TMPDIR/last-pr-comment.md" "No findings."
+
+echo "PASS"

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -1,0 +1,23 @@
+name: Agent build
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  build:
+    if: github.event.label.name == 'agent:build'
+    runs-on: [self-hosted, macOS, codex]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Run build stage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: .github/scripts/agent-build.sh

--- a/.github/workflows/agent-plan.yml
+++ b/.github/workflows/agent-plan.yml
@@ -1,0 +1,23 @@
+name: Agent plan
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  plan:
+    if: github.event.label.name == 'agent:plan'
+    runs-on: [self-hosted, macOS, codex]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Run planning stage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: .github/scripts/agent-plan.sh

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -1,0 +1,23 @@
+name: Agent review
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  review:
+    if: github.event.label.name == 'agent:review'
+    runs-on: [self-hosted, macOS, codex]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Run review stage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: .github/scripts/agent-review.sh

--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ The agent environment needs:
 - `git`, `gh` (GitHub CLI, authenticated)
 - Python 3.12+
 - Web access (to research companies and fetch career pages)
+
+## GitHub Hybrid Agent Automation
+
+This repo also includes a personal-use GitHub-first automation loop for general engineering tasks.
+
+- Open an issue using the `Agent task` template
+- Add the `agent:plan` label to generate a plan
+- Review `ai/runs/<issue>/Spec.md` and `Plan.json`
+- Add the `agent:build` label to execute the approved plan
+- Review the PR on GitHub, then add the `agent:review` label to the PR for a bounded review pass
+
+See `docs/14-github-hybrid-agent-automation.md` for setup and operating details.

--- a/docs/14-github-hybrid-agent-automation.md
+++ b/docs/14-github-hybrid-agent-automation.md
@@ -1,0 +1,43 @@
+# GitHub Hybrid Agent Automation
+
+## Setup
+
+1. Install a self-hosted macOS GitHub runner with label `codex`.
+2. Ensure `git`, `gh`, `jq`, `claude`, and `codex` are installed and authenticated on the runner.
+3. Ensure `pnpm` is available as an actual executable on `PATH`, not only through `corepack pnpm`, so `turbo` can discover the package manager binary during lint/build tasks.
+4. Create these issue labels:
+   - `agent:plan`
+   - `agent:build-ready`
+   - `agent:build`
+   - `agent:blocked`
+   - `agent:done`
+5. Create this PR label:
+   - `agent:review`
+
+## Operating loop
+
+1. Open an issue with the `Agent task` template.
+2. Add `agent:plan` to the issue.
+3. Review `ai/runs/<issue>/Spec.md` and `ai/runs/<issue>/Plan.json`.
+4. Add `agent:build` to the issue.
+5. Review the PR that the build stage creates or updates.
+6. Add `agent:review` to the PR when you want the bounded review pass to run.
+
+## Artifacts
+
+Each issue stores durable run state in `ai/runs/<issue-number>/`:
+
+- `Goal.md`
+- `Spec.md`
+- `Plan.json`
+- `Build.md`
+- `Review.md`
+- `Status.json`
+
+## Current limitations
+
+- Private repos only.
+- The self-hosted runner must be online.
+- Build runs only after explicit user relabeling.
+- No auto-merge in v1.
+- No slash-command or comment-command support in v1.


### PR DESCRIPTION
## Summary

Add a GitHub-first hybrid automation loop for personal engineering tasks in `jobseek`.

This PR adds:
- issue-driven planning workflow (`agent:plan`)
- issue-driven build workflow (`agent:build`)
- PR-driven bounded review workflow (`agent:review`)
- reusable shell helpers under `.github/scripts/`
- an `Agent task` issue template
- operator documentation for runner setup and usage

## Why

The repo already uses GitHub as an agent control plane for company-request resolution. This extends that pattern for general engineering tasks while keeping GitHub as the source of truth and the local Mac as the execution surface.

## Validation

Ran successfully in the isolated worktree:
- `bash .github/scripts/test-agent-automation.sh`
- `bash -n .github/scripts/agent-lib.sh .github/scripts/agent-plan.sh .github/scripts/agent-build.sh .github/scripts/agent-review.sh .github/scripts/test-agent-automation.sh`
- `PATH=/tmp/pnpm-bin:$PATH COREPACK_HOME=/tmp/corepack pnpm lint`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_workflow.py tests/test_workspace_git.py -v` (from `apps/crawler/`)

## Notes

Runner-side setup still required after merge:
- install/register the self-hosted runner with label `codex`
- ensure `pnpm` exists as a real executable on `PATH`
- ensure `gh`, `jq`, `claude`, and `codex` are installed and authenticated
