### PR TITLE
Phase 2: Resume scoring pipeline

### DIFF
--- a/apps/crawler/data/alert-filters.yaml
+++ b/apps/crawler/data/alert-filters.yaml
@@ -24,3 +24,6 @@ require:
 
 output:
   limit: 100
+
+score:
+  explain_top_n: 20   # number of top-overlap jobs to send to LLM for explanation

--- a/apps/crawler/src/cli.py
+++ b/apps/crawler/src/cli.py
@@ -125,6 +125,36 @@ def parse_args() -> argparse.Namespace:
         help="Output format (default: json)",
     )
 
+    parse_resume_p = sub.add_parser(
+        "parse-resume",
+        help="Extract resume skills profile to ai/resume-parsed.yaml",
+    )
+    parse_resume_p.add_argument(
+        "--resume",
+        required=True,
+        help="Path to resume file (.tex, .pdf, .txt, .md)",
+    )
+    parse_resume_p.add_argument(
+        "--output",
+        default="ai/resume-parsed.yaml",
+        help="Output YAML path (default: ai/resume-parsed.yaml)",
+    )
+
+    score_p = sub.add_parser(
+        "score",
+        help="Score filtered jobs against parsed resume",
+    )
+    score_p.add_argument(
+        "--filters",
+        default="data/alert-filters.yaml",
+        help="Path to filters YAML (default: data/alert-filters.yaml)",
+    )
+    score_p.add_argument(
+        "--resume",
+        default="ai/resume-parsed.yaml",
+        help="Path to parsed resume YAML (default: ai/resume-parsed.yaml)",
+    )
+
     return parser.parse_args()
 
 
@@ -326,6 +356,112 @@ async def run() -> None:
                             f"{str(r.get('work_permit_support') or ''):<8} "
                             f"{str(r.get('first_seen_at') or '')[:10]}"
                         )
+
+        elif args.command == "parse-resume":
+            from src.core.enrich.providers import create_sync_provider
+            from src.core.score.resume import parse_resume_with_llm, save_resume
+
+            provider = create_sync_provider(
+                settings.enrich_provider or "gemini",
+                settings.enrich_model or "gemini-2.0-flash",
+                settings.enrich_api_key,
+            )
+            parsed = await parse_resume_with_llm(args.resume, provider)
+            save_resume(parsed, args.output)
+            print(
+                f"Resume parsed: {len(parsed.technologies)} technologies, "
+                f"{len(parsed.keywords)} keywords → {args.output}"
+            )
+
+        elif args.command == "score":
+            import asyncio as _asyncio
+            from pathlib import Path
+
+            import yaml
+
+            from src.core.enrich.providers import create_sync_provider
+            from src.core.score.explain import explain_match
+            from src.core.score.overlap import compute_overlap
+            from src.core.score.resume import load_resume, resume_hash
+            from src.queries.score import fetch_unscored_jobs, upsert_explanation, upsert_score
+
+            resume_path = Path(args.resume)
+            if not resume_path.exists():
+                print(
+                    f"Error: {resume_path} not found. "
+                    "Run `crawler parse-resume --resume <path>` first."
+                )
+                raise SystemExit(1)
+
+            filters_raw = yaml.safe_load(Path(args.filters).read_text(encoding="utf-8"))
+            exclude_patterns = filters_raw.get("exclude_title_patterns") or []
+            exclude_regex = "|".join(exclude_patterns) if exclude_patterns else "(?!)"
+            experience_max = (filters_raw.get("require") or {}).get("experience_max")
+            explain_top_n = (filters_raw.get("score") or {}).get("explain_top_n", 20)
+            rate_limit_rpm: int = settings.enrich_rate_limit_rpm
+
+            parsed = load_resume(resume_path)
+            r_hash = resume_hash(parsed)
+
+            local_pool = await create_local_pool()
+            async with local_pool.acquire() as conn:
+                jobs = await fetch_unscored_jobs(
+                    conn,
+                    resume_hash=r_hash,
+                    exclude_title_regex=exclude_regex,
+                    experience_max=experience_max,
+                )
+
+            if not jobs:
+                print("No new jobs to score.")
+                raise SystemExit(0)
+
+            scored = [(job, compute_overlap(parsed, job)) for job in jobs]
+            scored.sort(key=lambda x: x[1], reverse=True)
+
+            async with local_pool.acquire() as conn:
+                for job, score in scored:
+                    await upsert_score(
+                        conn,
+                        posting_id=str(job["posting_id"]),
+                        resume_hash=r_hash,
+                        overlap_score=score,
+                    )
+
+            provider = create_sync_provider(
+                settings.enrich_provider or "gemini",
+                settings.enrich_model or "gemini-2.0-flash",
+                settings.enrich_api_key,
+            )
+
+            top_jobs = scored[:explain_top_n]
+            explained = 0
+            for i, (job, _score) in enumerate(top_jobs):
+                if i > 0:
+                    await _asyncio.sleep(60 / rate_limit_rpm)
+                try:
+                    explanation = await explain_match(parsed, job, provider)
+                    async with local_pool.acquire() as conn:
+                        await upsert_explanation(
+                            conn,
+                            posting_id=str(job["posting_id"]),
+                            explanation=explanation,
+                        )
+                    explained += 1
+                except Exception as exc:
+                    log.warning(
+                        "score.explain_failed",
+                        posting_id=str(job["posting_id"]),
+                        error=str(exc),
+                    )
+
+            top = scored[0]
+            print(
+                f"Scored {len(scored)} jobs. "
+                f"Explained top {explained}. "
+                f"Top match: {top[0].get('title')} @ {top[0].get('company_name')} "
+                f"(score {top[1]})"
+            )
 
     finally:
         log.info("cli.shutting_down")

--- a/apps/crawler/src/core/score/explain.py
+++ b/apps/crawler/src/core/score/explain.py
@@ -1,0 +1,64 @@
+"""LLM-generated fit explanation for a job match."""
+
+from __future__ import annotations
+
+import structlog
+
+from src.core.score.resume import ResumeParsed
+
+log = structlog.get_logger()
+
+_EXPLAIN_SYSTEM = """\
+You are a career advisor. Given a candidate profile and a job posting, write 2-3 sentences \
+explaining why this job is a good match. Be specific — mention shared technologies or domain \
+overlap. Be honest if the match is weak.
+"""
+
+_EXPLAIN_SCHEMA = {
+    "type": "object",
+    "properties": {"explanation": {"type": "string"}},
+    "required": ["explanation"],
+}
+
+
+async def explain_match(
+    resume: ResumeParsed,
+    job: dict,
+    provider,
+) -> str:
+    """Return a 2-3 sentence fit explanation.
+
+    provider — SyncProvider instance with:
+        async def generate(system_prompt, user_content, response_schema) -> tuple[dict, LLMUsage]
+
+    The caller is responsible for rate limiting between calls (sleep 60/rpm seconds).
+    """
+    enrichment = job.get("enrichment") or {}
+
+    user_msg = "\n".join([
+        "Candidate profile:",
+        f"  Occupation: {resume.occupation or 'not specified'}",
+        f"  Experience: {resume.experience_years or 'not specified'} years",
+        f"  Technologies: {', '.join(resume.technologies) or 'none listed'}",
+        f"  Keywords: {', '.join(resume.keywords) or 'none listed'}",
+        "",
+        "Job posting:",
+        f"  Title: {job.get('title') or 'Unknown'}",
+        f"  Company: {job.get('company_name') or 'Unknown'}",
+        f"  Technologies: {', '.join(enrichment.get('technologies') or []) or 'none listed'}",
+        f"  Keywords: {', '.join(enrichment.get('keywords') or []) or 'none listed'}",
+        f"  Seniority: {enrichment.get('seniority') or 'not specified'}",
+    ])
+
+    result_dict, usage = await provider.generate(
+        system_prompt=_EXPLAIN_SYSTEM,
+        user_content=user_msg,
+        response_schema=_EXPLAIN_SCHEMA,
+    )
+    log.info(
+        "score.explain_call",
+        title=job.get("title"),
+        company=job.get("company_name"),
+        input_tokens=usage.input_tokens if usage else None,
+    )
+    return result_dict.get("explanation", "")

--- a/apps/crawler/src/core/score/overlap.py
+++ b/apps/crawler/src/core/score/overlap.py
@@ -1,0 +1,40 @@
+"""Pure-Python overlap score between a parsed resume and an enriched job.
+
+No I/O. No LLM calls. Fully deterministic and unit-testable.
+"""
+
+from __future__ import annotations
+
+from src.core.score.resume import ResumeParsed
+
+# Seniority values that are a good fit for an early-career resume.
+# None (unknown) is treated as acceptable.
+_PREFERRED_SENIORITY: frozenset[str | None] = frozenset({"intern", "entry", "mid", None})
+
+# Component weights — must sum to 1.0.
+_TECH_WEIGHT = 0.5
+_KW_WEIGHT = 0.3
+_SENIORITY_WEIGHT = 0.2
+
+
+def compute_overlap(resume: ResumeParsed, job: dict) -> float:
+    """Return a 0–100 overlap score.
+
+    job must have an 'enrichment' key (dict or None) with optional
+    'technologies' (list[str]), 'keywords' (list[str]), and 'seniority' (str | None).
+    """
+    enrichment = job.get("enrichment") or {}
+
+    job_techs = {t.lower() for t in (enrichment.get("technologies") or [])}
+    job_kws = {k.lower() for k in (enrichment.get("keywords") or [])}
+    job_seniority: str | None = enrichment.get("seniority")
+
+    resume_techs = {t.lower() for t in resume.technologies}
+    resume_kws = {k.lower() for k in resume.keywords}
+
+    tech_score = len(resume_techs & job_techs) / max(len(job_techs), 1)
+    kw_score = len(resume_kws & job_kws) / max(len(job_kws), 1)
+    seniority_score = 1.0 if job_seniority in _PREFERRED_SENIORITY else 0.5
+
+    raw = tech_score * _TECH_WEIGHT + kw_score * _KW_WEIGHT + seniority_score * _SENIORITY_WEIGHT
+    return round(raw * 100, 2)

--- a/apps/crawler/src/core/score/resume.py
+++ b/apps/crawler/src/core/score/resume.py
@@ -1,0 +1,97 @@
+"""Resume parsing, YAML I/O, and hash utilities."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel
+
+Education = Literal["none", "vocational", "associate", "bachelor", "master", "doctorate"]
+
+_PARSE_SYSTEM_PROMPT = """\
+You are a structured data extractor for resumes. Extract a skills profile from the resume text.
+
+Rules:
+- Extract only what is explicitly stated. Do not guess.
+- Return null for any field where the information is absent.
+
+Field guidance:
+technologies — Specific named tools, frameworks, and languages. Use proper casing (e.g. "PostgreSQL" \
+not "postgres", "React" not "react"). Do not include generic categories like "databases" or "cloud".
+keywords — 5-10 lowercase terms describing the candidate's role function, domain, and industry. \
+Do NOT include technology names (those go in technologies).
+experience_years — Total years of professional experience as a single integer. Null if not determinable.
+education — Highest completed degree: "none", "vocational", "associate", "bachelor", "master", \
+"doctorate". Null if not stated.
+occupation — Primary job function in English, without seniority qualifiers. \
+E.g. "Software Engineer", "Data Analyst".
+"""
+
+
+class ResumeParsed(BaseModel):
+    technologies: list[str] = []
+    keywords: list[str] = []
+    experience_years: int | None = None
+    education: Education | None = None
+    occupation: str | None = None
+
+
+def load_resume(path: str | Path) -> ResumeParsed:
+    """Load ai/resume-parsed.yaml into ResumeParsed. Raises FileNotFoundError if missing."""
+    data = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    return ResumeParsed.model_validate(data or {})
+
+
+def save_resume(parsed: ResumeParsed, path: str | Path) -> None:
+    """Write ResumeParsed to YAML (creates parent dirs as needed)."""
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        yaml.dump(parsed.model_dump(), default_flow_style=False, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def resume_hash(parsed: ResumeParsed) -> str:
+    """Stable sha256 of the sorted YAML serialization. Changes when resume content changes."""
+    content = yaml.dump(parsed.model_dump(), default_flow_style=False, sort_keys=True)
+    return hashlib.sha256(content.encode()).hexdigest()
+
+
+def _extract_pdf_text(path: Path) -> str:
+    """Extract plain text from a PDF using pypdf (already in base deps)."""
+    from pypdf import PdfReader  # noqa: PLC0415
+
+    reader = PdfReader(str(path))
+    return "\n".join(page.extract_text() or "" for page in reader.pages)
+
+
+async def parse_resume_with_llm(source_path: str | Path, provider) -> ResumeParsed:
+    """Read a LaTeX/PDF/plain-text resume, call Gemini, return ResumeParsed.
+
+    provider — SyncProvider instance (GeminiSyncProvider from Phase 1).
+    Raises ValueError if no text can be extracted.
+    """
+    path = Path(source_path)
+    suffix = path.suffix.lower()
+
+    if suffix == ".pdf":
+        text = _extract_pdf_text(path)
+    else:
+        # .tex, .md, .txt — read directly; LLM ignores LaTeX markup
+        text = path.read_text(encoding="utf-8")
+
+    if not text.strip():
+        raise ValueError(f"No text extracted from {path}. If PDF, try converting to LaTeX first.")
+
+    response_schema = ResumeParsed.model_json_schema()
+
+    result_dict, _ = await provider.generate(
+        system_prompt=_PARSE_SYSTEM_PROMPT,
+        user_content=f"Resume:\n\n{text[:40_000]}",
+        response_schema=response_schema,
+    )
+    return ResumeParsed.model_validate(result_dict)

--- a/apps/crawler/src/migrations/versions/0005_add_resume_score_table.py
+++ b/apps/crawler/src/migrations/versions/0005_add_resume_score_table.py
@@ -1,0 +1,35 @@
+"""Add resume_score table.
+
+Revision ID: 0005
+Create Date: 2026-04-16
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS resume_score (
+            posting_id    uuid PRIMARY KEY REFERENCES job_posting(id) ON DELETE CASCADE,
+            resume_hash   text NOT NULL,
+            overlap_score numeric(5,2) NOT NULL,
+            explanation   text,
+            scored_at     timestamptz DEFAULT now(),
+            explained_at  timestamptz
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_resume_score_overlap "
+        "ON resume_score(overlap_score DESC)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS resume_score")

--- a/apps/crawler/src/queries/alert.py
+++ b/apps/crawler/src/queries/alert.py
@@ -18,15 +18,18 @@ _ALERT_QUERY = """
         jp.enrichment->>'seniority'             AS seniority,
         jp.enrichment                           AS enrichment_json,
         c.name                                  AS company_name,
-        c.slug                                  AS company_slug
+        c.slug                                  AS company_slug,
+        rs.overlap_score,
+        rs.explanation
     FROM job_posting jp
     JOIN company c ON c.id = jp.company_id
+    LEFT JOIN resume_score rs ON rs.posting_id = jp.id
     WHERE jp.is_active = true
       AND jp.enrichment IS NOT NULL
       AND ($4::text IS NULL OR jp.enrichment->>'work_permit_support' = $4)
       AND (jp.experience_max IS NULL OR jp.experience_max <= $1)
       AND (jp.titles[1] IS NULL OR jp.titles[1] !~* $2)
-    ORDER BY jp.first_seen_at DESC
+    ORDER BY rs.overlap_score DESC NULLS LAST, jp.first_seen_at DESC
     LIMIT $3
 """
 

--- a/apps/crawler/src/queries/score.py
+++ b/apps/crawler/src/queries/score.py
@@ -1,0 +1,81 @@
+"""DB queries for resume_score table."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+# Fetch jobs that need scoring:
+#   - active + enriched + passed cheap filters
+#   - not yet scored OR scored with a different resume hash
+_FETCH_UNSCORED = """
+    SELECT
+        jp.id          AS posting_id,
+        jp.titles[1]   AS title,
+        jp.enrichment,
+        c.name         AS company_name,
+        jp.first_seen_at
+    FROM job_posting jp
+    JOIN company c ON c.id = jp.company_id
+    LEFT JOIN resume_score rs ON rs.posting_id = jp.id
+    WHERE jp.is_active = true
+      AND jp.enrichment IS NOT NULL
+      AND jp.to_be_enriched = false
+      AND jp.titles[1] !~* $1
+      AND (jp.experience_max IS NULL OR jp.experience_max <= $2)
+      AND (rs.posting_id IS NULL OR rs.resume_hash != $3)
+    ORDER BY jp.first_seen_at DESC
+"""
+
+_UPSERT_SCORE = """
+    INSERT INTO resume_score (posting_id, resume_hash, overlap_score, scored_at)
+    VALUES ($1, $2, $3, now())
+    ON CONFLICT (posting_id) DO UPDATE
+        SET resume_hash   = EXCLUDED.resume_hash,
+            overlap_score = EXCLUDED.overlap_score,
+            scored_at     = now(),
+            explanation   = NULL,
+            explained_at  = NULL
+"""
+
+_UPSERT_EXPLANATION = """
+    UPDATE resume_score
+    SET explanation  = $1,
+        explained_at = now()
+    WHERE posting_id = $2
+"""
+
+
+async def fetch_unscored_jobs(
+    conn: asyncpg.Connection,
+    *,
+    resume_hash: str,
+    exclude_title_regex: str,
+    experience_max: int | None,
+) -> list[dict[str, Any]]:
+    """Return unscored (or stale-hash) jobs as plain dicts."""
+    cap = experience_max if experience_max is not None else 9999
+    rows = await conn.fetch(_FETCH_UNSCORED, exclude_title_regex, cap, resume_hash)
+    return [dict(r) for r in rows]
+
+
+async def upsert_score(
+    conn: asyncpg.Connection,
+    *,
+    posting_id: str,
+    resume_hash: str,
+    overlap_score: float,
+) -> None:
+    """Insert or replace a score row. Clears explanation on re-score."""
+    await conn.execute(_UPSERT_SCORE, posting_id, resume_hash, overlap_score)
+
+
+async def upsert_explanation(
+    conn: asyncpg.Connection,
+    *,
+    posting_id: str,
+    explanation: str,
+) -> None:
+    """Write the LLM explanation text and set explained_at."""
+    await conn.execute(_UPSERT_EXPLANATION, explanation, posting_id)

--- a/apps/crawler/tests/test_overlap.py
+++ b/apps/crawler/tests/test_overlap.py
@@ -1,0 +1,114 @@
+"""Tests for src/core/score/overlap.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.core.score.overlap import compute_overlap
+from src.core.score.resume import ResumeParsed
+
+
+def _job(technologies=None, keywords=None, seniority=None):
+    return {
+        "enrichment": {
+            "technologies": technologies or [],
+            "keywords": keywords or [],
+            "seniority": seniority,
+        }
+    }
+
+
+def test_full_tech_and_keyword_match():
+    resume = ResumeParsed(technologies=["Python", "PostgreSQL"], keywords=["backend", "api"])
+    job = _job(technologies=["Python", "PostgreSQL"], keywords=["backend", "api"])
+    score = compute_overlap(resume, job)
+    # tech=1.0*0.5, kw=1.0*0.3, seniority=None→1.0*0.2 → 100.0
+    assert score == 100.0
+
+
+def test_zero_tech_and_keyword_match():
+    resume = ResumeParsed(technologies=["Python"], keywords=["backend"])
+    job = _job(technologies=["Java"], keywords=["finance"])
+    score = compute_overlap(resume, job)
+    # tech=0, kw=0, seniority=None→1.0*0.2 → 20.0
+    assert score == 20.0
+
+
+def test_partial_tech_overlap():
+    resume = ResumeParsed(technologies=["Python", "Go", "React"])
+    job = _job(technologies=["Python", "Java"])
+    score = compute_overlap(resume, job)
+    # tech=1/2=0.5*0.5=0.25, kw=0, seniority=None→1.0*0.2 → 45.0
+    assert score == 45.0
+
+
+def test_seniority_penalty_for_senior():
+    resume = ResumeParsed(technologies=[], keywords=[])
+    job = _job(seniority="senior")
+    score = compute_overlap(resume, job)
+    # tech=0, kw=0, seniority=0.5*0.2 → 10.0
+    assert score == 10.0
+
+
+def test_seniority_penalty_for_director():
+    resume = ResumeParsed(technologies=[], keywords=[])
+    job = _job(seniority="director")
+    score = compute_overlap(resume, job)
+    assert score == 10.0
+
+
+def test_seniority_ok_for_entry():
+    resume = ResumeParsed(technologies=[], keywords=[])
+    job = _job(seniority="entry")
+    score = compute_overlap(resume, job)
+    assert score == 20.0
+
+
+def test_seniority_ok_for_intern():
+    resume = ResumeParsed(technologies=[], keywords=[])
+    job = _job(seniority="intern")
+    score = compute_overlap(resume, job)
+    assert score == 20.0
+
+
+def test_null_seniority_is_ok():
+    resume = ResumeParsed(technologies=[], keywords=[])
+    job = _job(seniority=None)
+    score = compute_overlap(resume, job)
+    assert score == 20.0
+
+
+def test_case_insensitive_match():
+    resume = ResumeParsed(technologies=["python", "postgresql"], keywords=["Backend"])
+    job = _job(technologies=["Python", "PostgreSQL"], keywords=["backend"])
+    score = compute_overlap(resume, job)
+    assert score == 100.0
+
+
+def test_empty_resume_technologies():
+    resume = ResumeParsed(technologies=[])
+    job = _job(technologies=["Python", "Go"])
+    score = compute_overlap(resume, job)
+    # tech=0/2=0, seniority=None→1.0*0.2 → 20.0
+    assert score == 20.0
+
+
+def test_null_enrichment_field():
+    resume = ResumeParsed(technologies=["Python"], keywords=["backend"])
+    job = {"enrichment": None}
+    score = compute_overlap(resume, job)
+    assert score == 20.0
+
+
+def test_missing_enrichment_key():
+    resume = ResumeParsed(technologies=["Python"])
+    job = {}
+    score = compute_overlap(resume, job)
+    assert score == 20.0
+
+
+def test_score_is_in_range():
+    resume = ResumeParsed(technologies=["Python"] * 10, keywords=["backend"] * 5)
+    job = _job(technologies=["Python"] * 10, keywords=["backend"] * 5, seniority="entry")
+    score = compute_overlap(resume, job)
+    assert 0.0 <= score <= 100.0

--- a/apps/crawler/tests/test_resume_parse.py
+++ b/apps/crawler/tests/test_resume_parse.py
@@ -1,0 +1,63 @@
+"""Tests for src/core/score/resume.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.core.score.resume import ResumeParsed, load_resume, resume_hash, save_resume
+
+
+def test_roundtrip(tmp_path):
+    parsed = ResumeParsed(
+        technologies=["Python", "PostgreSQL"],
+        keywords=["backend", "data engineering"],
+        experience_years=2,
+        education="bachelor",
+        occupation="Software Engineer",
+    )
+    path = tmp_path / "resume-parsed.yaml"
+    save_resume(parsed, path)
+    loaded = load_resume(path)
+    assert loaded == parsed
+
+
+def test_hash_is_stable(tmp_path):
+    parsed = ResumeParsed(technologies=["Python"], keywords=["backend"], experience_years=1)
+    path = tmp_path / "resume-parsed.yaml"
+    save_resume(parsed, path)
+    h1 = resume_hash(load_resume(path))
+    h2 = resume_hash(load_resume(path))
+    assert h1 == h2
+
+
+def test_hash_changes_on_content_update():
+    p1 = ResumeParsed(technologies=["Python"])
+    p2 = ResumeParsed(technologies=["Python", "Go"])
+    assert resume_hash(p1) != resume_hash(p2)
+
+
+def test_empty_resume_defaults():
+    parsed = ResumeParsed()
+    assert parsed.technologies == []
+    assert parsed.keywords == []
+    assert parsed.experience_years is None
+    assert parsed.education is None
+    assert parsed.occupation is None
+    assert len(resume_hash(parsed)) == 64  # sha256 hex = 64 chars
+
+
+def test_invalid_education_raises():
+    with pytest.raises(Exception):
+        ResumeParsed(education="phd")  # not in Education literal
+
+
+def test_load_missing_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_resume(tmp_path / "nonexistent.yaml")
+
+
+def test_save_creates_parent_dirs(tmp_path):
+    parsed = ResumeParsed(technologies=["Python"])
+    path = tmp_path / "nested" / "dir" / "resume.yaml"
+    save_resume(parsed, path)
+    assert path.exists()


### PR DESCRIPTION
## Summary

Builds on Phase 1 to rank filtered job postings by resume fit using hybrid scoring:

- **`crawler parse-resume --resume <file>`** — Parse a resume (PDF/LaTeX/txt) via Gemini into a structured `ai/resume-parsed.yaml` profile
- **`crawler score`** — Compute overlap scores for all unscored jobs, persist to DB, then generate LLM explanations for the top N matches

## Architecture

- `src/core/score/resume.py` — ResumeParsed model (Pydantic), load/save YAML, SHA-256 hash for stale detection, parse_resume_with_llm
- `src/core/score/overlap.py` — Pure-Python deterministic scorer: tech (0.5) + keywords (0.3) + seniority (0.2) weights, 0–100 output
- `src/core/score/explain.py` — LLM career-advisor explanation for top-N matches
- `src/queries/score.py` — fetch_unscored_jobs, upsert_score, upsert_explanation
- `src/migrations/versions/0005_add_resume_score_table.py` — resume_score table with posting_id FK, overlap_score, explanation
- `src/queries/alert.py` — Extended with LEFT JOIN resume_score, sorted by overlap_score DESC NULLS LAST
- `src/cli.py` — parse-resume and score subcommands added

## Key design decisions

- Hybrid scoring: pure-Python overlap for bulk (no API calls), LLM explanations only for top N
- `resume_hash` (SHA-256 of sorted YAML) used as stale-detection key — re-scores only when resume changes
- `explain_top_n` configurable via `data/alert-filters.yaml` score section
- Rate limiting reuses `settings.enrich_rate_limit_rpm` (default 15 RPM)
- `ai/resume-parsed.yaml` is gitignored (the entire `ai/` directory is already in .gitignore)

## Test plan

- [ ] `uv run pytest tests/test_resume_parse.py tests/test_overlap.py -v` — 20 tests pass
- [ ] `crawler parse-resume --help`
- [ ] `crawler score --help`

Spec: `docs/local/superpowers/specs/2026-04-16-resume-scoring-design.md`

> **Note:** Depends on Phase 1 PR being merged first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)