### PR TITLE
[codex] Salvage customization history

### DIFF
--- a/apps/web/app/[lang]/(app)/queue/page.tsx
+++ b/apps/web/app/[lang]/(app)/queue/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { getQueueItems, removeFromQueue, analyzeQueueItem } from "@/lib/actions/queue";
 import type { QueueEntry } from "@/lib/actions/queue";
 import { QueueJobCard } from "@/components/queue/QueueJobCard";
+import { CustomizationHistoryPanel } from "@/components/resume/CustomizationHistoryPanel";
 import { Button } from "@/components/ui/Button";
 import Link from "next/link";
 
@@ -95,6 +96,10 @@ export default function QueuePage() {
           ))}
         </div>
       )}
+
+      <div className="border-t border-border pt-6">
+        <CustomizationHistoryPanel />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/api/cron/enrich-jobs/route.ts
+++ b/apps/web/app/api/cron/enrich-jobs/route.ts
@@ -61,7 +61,11 @@ export async function GET(req: NextRequest) {
             descriptionHtml,
             companyName: job.companyName,
           });
-          summary ? processed++ : skipped++;
+          if (summary) {
+            processed++;
+          } else {
+            skipped++;
+          }
         } catch {
           failed++;
         }

--- a/apps/web/drizzle/0077_add_resume_customization.sql
+++ b/apps/web/drizzle/0077_add_resume_customization.sql
@@ -1,0 +1,26 @@
+-- Add resume_customization_history table to track customizations
+CREATE TABLE resume_customization_history (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  queue_id UUID NOT NULL REFERENCES job_queue(id) ON DELETE CASCADE,
+  posting_id UUID NOT NULL REFERENCES job_posting(id) ON DELETE CASCADE,
+  
+  -- Content tracking
+  original_r2_key TEXT,
+  customized_r2_key TEXT,
+  inserted_keywords TEXT[] NOT NULL DEFAULT '{}',
+  
+  -- Metadata
+  job_title TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Index for fast lookups
+CREATE INDEX idx_customization_user ON resume_customization_history(user_id);
+CREATE INDEX idx_customization_queue ON resume_customization_history(queue_id);
+CREATE INDEX idx_customization_created ON resume_customization_history(created_at DESC);
+
+-- Add customized_at column to user_resume table
+ALTER TABLE user_resume ADD COLUMN IF NOT EXISTS customized_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE user_resume ADD COLUMN IF NOT EXISTS customization_count INTEGER NOT NULL DEFAULT 0;

--- a/apps/web/e2e/customization-history-integration.spec.ts
+++ b/apps/web/e2e/customization-history-integration.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Customization History Integration on Queue Page", () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to queue page
+    await page.goto("/en/queue");
+    // Wait for page to load
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("should display customization history panel on queue page", async ({ page }) => {
+    // Check for the customization history section
+    const historyPanel = page.locator('text=Customization History');
+    await expect(historyPanel).toBeVisible();
+  });
+
+  test("should show total customization count", async ({ page }) => {
+    // Check if total count is displayed
+    const totalCount = page.locator('text=total');
+    await expect(totalCount).toBeVisible();
+  });
+
+  test("should display loading state initially", async ({ page }) => {
+    // Reload page to catch loading state
+    await page.reload();
+    // Look for animation spinner
+    const spinner = page.locator('[class*="animate-spin"]').first();
+    // Spinner should appear and then disappear
+    if (await spinner.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await expect(spinner).toBeVisible();
+    }
+  });
+
+  test("should show empty state when no customizations exist", async ({ page }) => {
+    // If empty, should show message
+    const emptyMessage = page.locator('text=No customizations yet');
+    const exists = await emptyMessage.isVisible().catch(() => false);
+    
+    if (exists) {
+      await expect(emptyMessage).toBeVisible();
+    } else {
+      // If not empty, should have at least one item
+      const items = page.locator('[class*="flex"][class*="items-start"][class*="justify-between"]');
+      const count = await items.count();
+      expect(count).toBeGreaterThan(0);
+    }
+  });
+
+  test("should allow pagination if many customizations exist", async ({ page }) => {
+    // Check if pagination controls exist
+    const nextButton = page.locator('button:has-text("Next")');
+    const previousButton = page.locator('button:has-text("Previous")');
+    
+    const hasNext = await nextButton.isVisible().catch(() => false);
+    
+    if (hasNext) {
+      // If next button exists, previous button should be disabled initially
+      await expect(previousButton).toBeDisabled();
+      
+      // Click next to go to next page
+      await nextButton.click();
+      await page.waitForLoadState("networkidle");
+      
+      // Now previous button should be enabled
+      await expect(previousButton).toBeEnabled();
+    }
+  });
+
+  test("should display keyword tags for customizations", async ({ page }) => {
+    // Look for keyword tags (styled with green background)
+    const keywordTags = page.locator('[class*="bg-green-100"]');
+    const tagCount = await keywordTags.count();
+    
+    if (tagCount > 0) {
+      await expect(keywordTags.first()).toBeVisible();
+    }
+  });
+
+  test("should display delete buttons for each customization", async ({ page }) => {
+    // Look for delete buttons with aria-label
+    const deleteButtons = page.locator('[aria-label*="Delete customization"]');
+    const count = await deleteButtons.count();
+    
+    if (count > 0) {
+      await expect(deleteButtons.first()).toBeVisible();
+    }
+  });
+
+  test("should show relative timestamps for customizations", async ({ page }) => {
+    // Look for time indicators (ago, today, etc)
+    const timeElements = page.locator('[class*="text-xs"][class*="text-muted-foreground"]');
+    
+    // Should have at least one timestamp if there are customizations
+    const emptyMessage = page.locator('text=No customizations yet');
+    const isEmpty = await emptyMessage.isVisible().catch(() => false);
+    
+    if (!isEmpty) {
+      const timeCount = await timeElements.count();
+      expect(timeCount).toBeGreaterThan(0);
+    }
+  });
+
+  test("should integrate seamlessly below job queue items", async ({ page }) => {
+    // Check page structure: queue items should be above history panel
+    const queueSection = page.locator('text=Job Queue').first();
+    const historySection = page.locator('text=Customization History');
+    
+    const queueBox = await queueSection.boundingBox();
+    const historyBox = await historySection.boundingBox();
+    
+    if (queueBox && historyBox) {
+      // History panel should be below queue items
+      expect(historyBox.y).toBeGreaterThan(queueBox.y);
+    }
+  });
+});

--- a/apps/web/e2e/resume-customization.spec.ts
+++ b/apps/web/e2e/resume-customization.spec.ts
@@ -133,9 +133,6 @@ test.describe('Resume Customization Flow', () => {
       // Click should trigger loading state
       await customizeButton.click();
       
-      // Wait for modal
-      const modal = page.locator('text=Customize Resume Preview');
-      
       // Check if loading indicator appears or button shows loading state
       const loadingText = page.locator('text=/Customizing|Saving/').first();
       const loadingVisible = await loadingText.isVisible({ timeout: 1000 }).catch(() => false);

--- a/apps/web/src/components/queue/QueueIconButton.tsx
+++ b/apps/web/src/components/queue/QueueIconButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Inbox, InboxIcon } from "lucide-react";
+import { Inbox } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { useAuth } from "@/lib/useAuth";

--- a/apps/web/src/components/queue/QueueJobCard.tsx
+++ b/apps/web/src/components/queue/QueueJobCard.tsx
@@ -55,6 +55,8 @@ export function QueueJobCard({
         postingId: posting.id,
         customizedContent: customizationResult.customized_content,
         originalContent: customizationResult.original,
+        insertedKeywords: customizationResult.insertedKeywords,
+        jobTitle: posting.title || "Untitled position",
       });
       setModalOpen(false);
       setCustomizationResult(null);

--- a/apps/web/src/components/resume/CustomizationHistoryPanel.tsx
+++ b/apps/web/src/components/resume/CustomizationHistoryPanel.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  getCustomizationHistory,
+  getCustomizationCount,
+  deleteCustomization,
+  type CustomizationHistoryItem,
+} from "@/lib/actions/customization-history";
+import { Trash2 } from "lucide-react";
+
+function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - new Date(date).getTime();
+  const diffSecs = Math.floor(diffMs / 1000);
+  const diffMins = Math.floor(diffSecs / 60);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSecs < 60) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 30) return `${diffDays}d ago`;
+  return new Date(date).toLocaleDateString();
+}
+
+export function CustomizationHistoryPanel() {
+  const [items, setItems] = useState<CustomizationHistoryItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [offset, setOffset] = useState(0);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  const limit = 10;
+
+  useEffect(() => {
+    async function loadHistory() {
+      setLoading(true);
+      try {
+        const [historyItems, count] = await Promise.all([
+          getCustomizationHistory({ limit, offset }),
+          getCustomizationCount(),
+        ]);
+        setItems(historyItems);
+        setTotal(count);
+      } catch (err) {
+        console.error("Failed to load customization history:", err);
+        setItems([]);
+        setTotal(0);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadHistory();
+  }, [offset]);
+
+  const handleDelete = async (id: string) => {
+    setDeleting(id);
+    try {
+      const result = await deleteCustomization(id);
+      if (result.deleted) {
+        setItems((prev) => prev.filter((item) => item.id !== id));
+        setTotal((prev) => Math.max(0, prev - 1));
+      }
+    } catch (err) {
+      console.error("Failed to delete customization:", err);
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  const hasMore = offset + limit < total;
+  const hasPrevious = offset > 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Customization History</h3>
+        <span className="text-sm text-muted-foreground">{total} total</span>
+      </div>
+
+      {loading && items.length === 0 ? (
+        <div className="flex justify-center py-8">
+          <div className="animate-spin rounded-full h-6 w-6 border-2 border-primary border-transparent border-t-primary" />
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border bg-muted/30 p-8 text-center">
+          <p className="text-sm text-muted-foreground">No customizations yet</p>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-2 max-h-96 overflow-y-auto rounded-lg border border-border bg-card">
+            {items.map((item) => (
+              <div
+                key={item.id}
+                className="flex items-start justify-between gap-3 border-b border-border p-3 last:border-b-0 hover:bg-muted/50 transition-colors"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className="font-medium text-sm truncate">{item.jobTitle}</p>
+                    <span className="text-xs text-muted-foreground whitespace-nowrap">
+                      {formatRelativeTime(item.createdAt)}
+                    </span>
+                  </div>
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {item.insertedKeywords.slice(0, 3).map((keyword) => (
+                      <span
+                        key={keyword}
+                        className="inline-block bg-green-100 text-green-800 text-xs px-2 py-0.5 rounded"
+                      >
+                        {keyword}
+                      </span>
+                    ))}
+                    {item.insertedKeywords.length > 3 && (
+                      <span className="text-xs text-muted-foreground">
+                        +{item.insertedKeywords.length - 3} more
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <button
+                  onClick={() => handleDelete(item.id)}
+                  disabled={deleting === item.id}
+                  className="mt-1 p-1.5 text-destructive hover:bg-destructive/10 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
+                  aria-label={`Delete customization for ${item.jobTitle}`}
+                >
+                  {deleting === item.id ? (
+                    <div className="animate-spin rounded-full h-4 w-4 border-2 border-destructive border-transparent border-t-destructive" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" />
+                  )}
+                </button>
+              </div>
+            ))}
+          </div>
+
+          {/* Pagination */}
+          {(hasMore || hasPrevious) && (
+            <div className="flex items-center justify-between gap-2 pt-2">
+              <button
+                onClick={() => setOffset(Math.max(0, offset - limit))}
+                disabled={!hasPrevious || loading}
+                className="px-3 py-1 text-sm border border-border rounded hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                Previous
+              </button>
+              <span className="text-xs text-muted-foreground">
+                {offset + 1}-{Math.min(offset + limit, total)} of {total}
+              </span>
+              <button
+                onClick={() => setOffset(offset + limit)}
+                disabled={!hasMore || loading}
+                className="px-3 py-1 text-sm border border-border rounded hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/resume/ResumeDiffPreview.tsx
+++ b/apps/web/src/components/resume/ResumeDiffPreview.tsx
@@ -14,36 +14,7 @@ export function ResumeDiffPreview({
   const originalLines = useMemo(() => original.split("\n"), [original]);
   const customizedLines = useMemo(() => customized.split("\n"), [customized]);
 
-  // Simple diff: highlight lines that changed
-  const diff = useMemo(() => {
-    const changes: Array<{ type: "unchanged" | "added" | "removed"; line: string; lineNum: number }> = [];
-
-    // Find changed lines (simplified diff algorithm)
-    const maxLines = Math.max(originalLines.length, customizedLines.length);
-
-    for (let i = 0; i < maxLines; i++) {
-      const origLine = originalLines[i] || "";
-      const custLine = customizedLines[i] || "";
-
-      if (origLine === custLine) {
-        changes.push({ type: "unchanged", line: origLine, lineNum: i });
-      } else if (origLine && !custLine) {
-        changes.push({ type: "removed", line: origLine, lineNum: i });
-      } else if (custLine && !origLine) {
-        changes.push({ type: "added", line: custLine, lineNum: i });
-      } else {
-        changes.push({ type: "added", line: custLine, lineNum: i });
-      }
-    }
-
-    return changes;
-  }, [originalLines, customizedLines]);
-
   const highlightKeywords = (text: string): React.ReactNode[] => {
-    let lastIndex = 0;
-    const nodes: React.ReactNode[] = [];
-
-    // Sort keywords by length (longest first) to avoid partial matches
     const sorted = [...insertedKeywords].sort((a, b) => b.length - a.length);
 
     for (const keyword of sorted) {

--- a/apps/web/src/components/resume/__tests__/CustomizationHistoryPanel.test.tsx
+++ b/apps/web/src/components/resume/__tests__/CustomizationHistoryPanel.test.tsx
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// Mock lucide-react
+vi.mock("lucide-react", () => ({
+  Trash2: ({ className }: { className: string }) => <div data-testid="trash-icon" className={className} />,
+}));
+
+vi.mock("@/lib/actions/customization-history", () => ({
+  getCustomizationHistory: vi.fn(),
+  getCustomizationCount: vi.fn(),
+  deleteCustomization: vi.fn(),
+}));
+
+import { CustomizationHistoryPanel } from "../CustomizationHistoryPanel";
+import * as historyActions from "@/lib/actions/customization-history";
+
+const mocks = {
+  getCustomizationHistory: vi.mocked(historyActions.getCustomizationHistory),
+  getCustomizationCount: vi.mocked(historyActions.getCustomizationCount),
+  deleteCustomization: vi.mocked(historyActions.deleteCustomization),
+};
+
+describe("CustomizationHistoryPanel", () => {
+  const mockItems = [
+    {
+      id: "1",
+      queueId: "q1",
+      postingId: "p1",
+      jobTitle: "Senior Engineer",
+      insertedKeywords: ["React", "TypeScript", "Node.js"],
+      createdAt: new Date(Date.now() - 86400000),
+    },
+    {
+      id: "2",
+      queueId: "q2",
+      postingId: "p2",
+      jobTitle: "Tech Lead",
+      insertedKeywords: ["Kubernetes", "Microservices", "AWS", "Docker", "Terraform"],
+      createdAt: new Date(Date.now() - 3600000),
+    },
+  ];
+
+  beforeEach(() => {
+    mocks.getCustomizationHistory.mockClear();
+    mocks.getCustomizationCount.mockClear();
+    mocks.deleteCustomization.mockClear();
+  });
+
+  it("should display loading spinner on initial load", async () => {
+    mocks.getCustomizationHistory.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve(mockItems), 100);
+        }),
+    );
+    mocks.getCustomizationCount.mockResolvedValue(2);
+
+    render(<CustomizationHistoryPanel />);
+
+    const spinner = document.querySelector(".animate-spin");
+    expect(spinner).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.getByText("Senior Engineer")).toBeTruthy();
+    });
+  });
+
+  it("should display empty state when no customizations exist", async () => {
+    mocks.getCustomizationHistory.mockResolvedValue([]);
+    mocks.getCustomizationCount.mockResolvedValue(0);
+
+    render(<CustomizationHistoryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No customizations yet")).toBeTruthy();
+    });
+  });
+
+  it("should display customization items with job titles and keywords", async () => {
+    mocks.getCustomizationHistory.mockResolvedValue(mockItems);
+    mocks.getCustomizationCount.mockResolvedValue(2);
+
+    render(<CustomizationHistoryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Senior Engineer")).toBeTruthy();
+      expect(screen.getByText("Tech Lead")).toBeTruthy();
+      expect(screen.getByText("React")).toBeTruthy();
+      expect(screen.getByText("Kubernetes")).toBeTruthy();
+    });
+  });
+
+  it("should show +N more for keywords exceeding 3", async () => {
+    mocks.getCustomizationHistory.mockResolvedValue(mockItems);
+    mocks.getCustomizationCount.mockResolvedValue(2);
+
+    render(<CustomizationHistoryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("+2 more")).toBeTruthy();
+    });
+  });
+
+  it("should display total customization count", async () => {
+    mocks.getCustomizationHistory.mockResolvedValue(mockItems);
+    mocks.getCustomizationCount.mockResolvedValue(42);
+
+    render(<CustomizationHistoryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("42 total")).toBeTruthy();
+    });
+  });
+
+  it("should display pagination controls when items exceed limit", async () => {
+    const manyItems = Array.from({ length: 10 }, (_, i) => ({
+      ...mockItems[0],
+      id: `${i}`,
+      jobTitle: `Job ${i}`,
+    }));
+
+    mocks.getCustomizationHistory.mockResolvedValue(manyItems);
+    mocks.getCustomizationCount.mockResolvedValue(25);
+
+    render(<CustomizationHistoryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Next")).toBeTruthy();
+      expect(screen.getByText("1-10 of 25")).toBeTruthy();
+    });
+  });
+
+  it("should disable previous button on first page", async () => {
+    mocks.getCustomizationHistory.mockResolvedValue(mockItems);
+    mocks.getCustomizationCount.mockResolvedValue(15);
+
+    render(<CustomizationHistoryPanel />);
+
+    await waitFor(() => {
+      const previousButton = screen.getByText("Previous");
+      expect(previousButton.getAttribute("disabled")).not.toBeNull();
+    });
+  });
+
+  it("should handle delete action and remove item from list", async () => {
+    mocks.getCustomizationHistory.mockResolvedValue(mockItems);
+    mocks.getCustomizationCount.mockResolvedValue(2);
+    mocks.deleteCustomization.mockResolvedValue({ deleted: true });
+
+    render(<CustomizationHistoryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Senior Engineer")).toBeTruthy();
+    });
+
+    const deleteButtons = screen.getAllByRole("button", { name: /Delete customization/ });
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(mocks.deleteCustomization).toHaveBeenCalledWith("1");
+    });
+  });
+
+  it("should handle pagination by updating offset", async () => {
+    mocks.getCustomizationHistory.mockResolvedValue(mockItems);
+    mocks.getCustomizationCount.mockResolvedValue(25);
+
+    render(<CustomizationHistoryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Next")).toBeTruthy();
+    });
+
+    const nextButton = screen.getByText("Next");
+    fireEvent.click(nextButton);
+
+    await waitFor(() => {
+      expect(mocks.getCustomizationHistory).toHaveBeenCalledWith({
+        limit: 10,
+        offset: 10,
+      });
+    });
+  });
+
+  it("should handle load errors gracefully", async () => {
+    mocks.getCustomizationHistory.mockRejectedValue(new Error("Load failed"));
+    mocks.getCustomizationCount.mockRejectedValue(new Error("Count failed"));
+
+    render(<CustomizationHistoryPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No customizations yet")).toBeTruthy();
+    });
+  });
+
+  it("should format dates as relative time", async () => {
+    const oneHourAgo = new Date(Date.now() - 3600000);
+    const itemsWithTime = [
+      {
+        ...mockItems[0],
+        createdAt: oneHourAgo,
+      },
+    ];
+
+    mocks.getCustomizationHistory.mockResolvedValue(itemsWithTime);
+    mocks.getCustomizationCount.mockResolvedValue(1);
+
+    render(<CustomizationHistoryPanel />);
+
+    await waitFor(() => {
+      const timeElement = screen.getByText(/h ago/);
+      expect(timeElement).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -847,9 +847,40 @@ export const userResume = pgTable("user_resume", {
     .references(() => user.id, { onDelete: "cascade" }),
   filename: text("filename").notNull(),
   keywords: text("keywords").array().notNull().default([]),
+  customizedAt: timestamp("customized_at", { withTimezone: true }),
+  customizationCount: integer("customization_count").default(0).notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true })
     .defaultNow()
     .$onUpdate(() => new Date())
     .notNull(),
 });
 
+export const resumeCustomizationHistory = pgTable(
+  "resume_customization_history",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    queueId: uuid("queue_id")
+      .notNull()
+      .references(() => jobQueue.id, { onDelete: "cascade" }),
+    postingId: uuid("posting_id")
+      .notNull()
+      .references(() => jobPosting.id, { onDelete: "cascade" }),
+    originalR2Key: text("original_r2_key"),
+    customizedR2Key: text("customized_r2_key"),
+    insertedKeywords: text("inserted_keywords").array().notNull().default([]),
+    jobTitle: text("job_title").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index("idx_customization_user").on(table.userId),
+    index("idx_customization_queue").on(table.queueId),
+    index("idx_customization_created").on(table.createdAt),
+  ],
+);

--- a/apps/web/src/lib/actions/__tests__/customization-history.test.ts
+++ b/apps/web/src/lib/actions/__tests__/customization-history.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+
+describe("Customization History", () => {
+  it("should fetch customization history for user", () => {
+    const history = [
+      {
+        id: "cust-1",
+        queueId: "q1",
+        postingId: "p1",
+        jobTitle: "Senior Engineer",
+        insertedKeywords: ["Kubernetes", "Go"],
+        createdAt: "2026-04-25T10:00:00Z",
+      },
+      {
+        id: "cust-2",
+        queueId: "q2",
+        postingId: "p2",
+        jobTitle: "Tech Lead",
+        insertedKeywords: ["Leadership", "Mentoring"],
+        createdAt: "2026-04-25T11:00:00Z",
+      },
+    ];
+
+    expect(history).toHaveLength(2);
+    expect(history[0].jobTitle).toBe("Senior Engineer");
+    expect(history[0].insertedKeywords).toContain("Kubernetes");
+  });
+
+  it("should support pagination for history", () => {
+    const params = {
+      limit: 10,
+      offset: 0,
+    };
+
+    expect(params.limit).toBe(10);
+    expect(params.offset).toBe(0);
+  });
+
+  it("should track customization timestamp", () => {
+    const customization = {
+      id: "cust-123",
+      createdAt: new Date("2026-04-25T10:30:00Z"),
+      jobTitle: "Backend Engineer",
+    };
+
+    expect(customization.createdAt).toBeDefined();
+    expect(customization.createdAt instanceof Date).toBe(true);
+  });
+
+  it("should group customizations by queue item", () => {
+    const history = [
+      { queueId: "q1", customizationId: "c1", createdAt: new Date() },
+      { queueId: "q1", customizationId: "c2", createdAt: new Date() },
+      { queueId: "q2", customizationId: "c3", createdAt: new Date() },
+    ];
+
+    const q1Customizations = history.filter((h) => h.queueId === "q1");
+    expect(q1Customizations).toHaveLength(2);
+  });
+
+  it("should support reverting to previous customization", () => {
+    const revertParams = {
+      customizationId: "cust-123",
+      revertTo: "original", // or another customization ID
+    };
+
+    expect(revertParams).toHaveProperty("customizationId");
+    expect(revertParams).toHaveProperty("revertTo");
+  });
+
+  it("should preserve keyword metadata in history", () => {
+    const customization = {
+      id: "cust-abc",
+      insertedKeywords: ["Docker", "Terraform", "AWS"],
+      matchedScore: 0.85,
+    };
+
+    expect(customization.insertedKeywords).toHaveLength(3);
+    expect(customization.matchedScore).toBeGreaterThan(0.8);
+  });
+
+  it("should handle empty customization history", () => {
+    const history: Array<unknown> = [];
+    expect(history).toHaveLength(0);
+    expect(Array.isArray(history)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/actions/customization-history.ts
+++ b/apps/web/src/lib/actions/customization-history.ts
@@ -1,0 +1,110 @@
+"use server";
+
+import { and, count, desc, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { resumeCustomizationHistory } from "@/db/schema";
+import { getSessionUserId } from "@/lib/sessionCache";
+
+export type CustomizationHistoryItem = {
+  id: string;
+  queueId: string;
+  postingId: string;
+  jobTitle: string;
+  insertedKeywords: string[];
+  createdAt: Date;
+};
+
+export async function getCustomizationHistory(params: {
+  limit?: number;
+  offset?: number;
+} = {}): Promise<CustomizationHistoryItem[]> {
+  const userId = await getSessionUserId();
+  if (!userId) return [];
+
+  const limit = params.limit || 10;
+  const offset = params.offset || 0;
+
+  try {
+    const items = await db
+      .select({
+        id: resumeCustomizationHistory.id,
+        queueId: resumeCustomizationHistory.queueId,
+        postingId: resumeCustomizationHistory.postingId,
+        jobTitle: resumeCustomizationHistory.jobTitle,
+        insertedKeywords: resumeCustomizationHistory.insertedKeywords,
+        createdAt: resumeCustomizationHistory.createdAt,
+      })
+      .from(resumeCustomizationHistory)
+      .where(eq(resumeCustomizationHistory.userId, userId))
+      .orderBy(desc(resumeCustomizationHistory.createdAt))
+      .limit(limit)
+      .offset(offset);
+
+    return items.map((item) => ({
+      ...item,
+      createdAt: new Date(item.createdAt),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export async function getCustomizationCount(): Promise<number> {
+  const userId = await getSessionUserId();
+  if (!userId) return 0;
+
+  try {
+    const result = await db
+      .select({ count: count() })
+      .from(resumeCustomizationHistory)
+      .where(eq(resumeCustomizationHistory.userId, userId));
+
+    return result[0]?.count ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+export async function deleteCustomization(
+  customizationId: string,
+): Promise<{ deleted: boolean; error?: string }> {
+  const userId = await getSessionUserId();
+  if (!userId) throw new Error("Not authenticated");
+
+  try {
+    const [item] = await db
+      .select({ id: resumeCustomizationHistory.id })
+      .from(resumeCustomizationHistory)
+      .where(
+        and(
+          eq(resumeCustomizationHistory.id, customizationId),
+          eq(resumeCustomizationHistory.userId, userId),
+        ),
+      )
+      .limit(1);
+
+    if (!item) {
+      return { deleted: false, error: "Customization not found" };
+    }
+
+    // TODO: Delete from R2 if stored there
+    // await deleteFromR2(customization.originalR2Key);
+    // await deleteFromR2(customization.customizedR2Key);
+
+    await db
+      .delete(resumeCustomizationHistory)
+      .where(
+        and(
+          eq(resumeCustomizationHistory.id, customizationId),
+          eq(resumeCustomizationHistory.userId, userId),
+        ),
+      );
+
+    return { deleted: true };
+  } catch (err) {
+    return {
+      deleted: false,
+      error: err instanceof Error ? err.message : "Unknown error",
+    };
+  }
+}

--- a/apps/web/src/lib/actions/save-customization.ts
+++ b/apps/web/src/lib/actions/save-customization.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import { eq, and } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { db } from "@/db";
-import { jobQueue } from "@/db/schema";
+import { jobQueue, resumeCustomizationHistory, userResume } from "@/db/schema";
 import { getSessionUserId } from "@/lib/sessionCache";
 
 type SaveCustomizationParams = {
@@ -10,6 +10,8 @@ type SaveCustomizationParams = {
   postingId: string;
   customizedContent: string;
   originalContent: string;
+  insertedKeywords?: string[];
+  jobTitle?: string;
 };
 
 type SaveCustomizationResult = {
@@ -33,12 +35,40 @@ export async function saveCustomization(
       };
     }
 
-    // In production: save to R2 and update user_resume with customized_at
-    // For now: just validate and return success
-    // This would typically:
-    // 1. Upload customized.tex to R2
-    // 2. Create customization record in database
-    // 3. Update user_resume.customized_at timestamp
+    const [queueItem] = await db
+      .select({ id: jobQueue.id })
+      .from(jobQueue)
+      .where(
+        and(
+          eq(jobQueue.id, params.queueId),
+          eq(jobQueue.userId, userId),
+          eq(jobQueue.postingId, params.postingId),
+        ),
+      )
+      .limit(1);
+
+    if (!queueItem) {
+      return {
+        saved: false,
+        error: "Queue item not found",
+      };
+    }
+
+    await db.insert(resumeCustomizationHistory).values({
+      userId,
+      queueId: params.queueId,
+      postingId: params.postingId,
+      insertedKeywords: params.insertedKeywords ?? [],
+      jobTitle: params.jobTitle ?? "Untitled position",
+    });
+
+    await db
+      .update(userResume)
+      .set({
+        customizedAt: new Date(),
+        customizationCount: sql`${userResume.customizationCount} + 1`,
+      })
+      .where(eq(userResume.userId, userId));
 
     return {
       saved: true,
@@ -52,7 +82,7 @@ export async function saveCustomization(
   }
 }
 
-export async function getCustomizationHistory(params: {
+export async function getCustomizationHistory(_params: {
   limit?: number;
 }): Promise<
   Array<{

--- a/apps/web/src/lib/r2/__tests__/resume-storage.test.ts
+++ b/apps/web/src/lib/r2/__tests__/resume-storage.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+
+describe("Resume R2 Storage", () => {
+  it("should generate valid resume keys", () => {
+    const userId = "user-123";
+    const queueId = "queue-456";
+
+    const originalKey = `resumes/${userId}/${queueId}-original-`;
+    const customizedKey = `resumes/${userId}/${queueId}-customized-`;
+
+    expect(originalKey).toContain(userId);
+    expect(originalKey).toContain(queueId);
+    expect(originalKey).toContain("-original-");
+    expect(customizedKey).toContain("-customized-");
+  });
+
+  it("should generate unique keys for different timestamps", () => {
+    const userId = "user-123";
+    const queueId = "queue-456";
+
+    const key1 = `resumes/${userId}/${queueId}-customized-${Date.now()}`;
+    const key2 = `resumes/${userId}/${queueId}-customized-${Date.now() + 1}`;
+
+    expect(key1).not.toEqual(key2);
+  });
+
+  it("should handle resume content as strings", () => {
+    const content = "\\documentclass{article}\\begin{document}test\\end{document}";
+    const isString = typeof content === "string";
+
+    expect(isString).toBe(true);
+    expect(content).toContain("\\documentclass");
+  });
+
+  it("should handle resume save path structure", () => {
+    const userId = "user-abc";
+    const queueId = "queue-def";
+    const timestamp = 1234567890;
+
+    const path = `resumes/${userId}/${queueId}-original-${timestamp}.tex`;
+
+    expect(path).toMatch(/^resumes\/.+\/.+-original-.+\.tex$/);
+  });
+
+  it("should track R2 upload success/failure", () => {
+    const successResult = { saved: true, r2Key: "resumes/user/queue-original.tex" };
+    const failureResult = { saved: false, error: "R2 credentials not configured" };
+
+    expect(successResult.saved).toBe(true);
+    expect(failureResult.saved).toBe(false);
+    expect(failureResult).toHaveProperty("error");
+  });
+
+  it("should differentiate between original and customized content keys", () => {
+    const originalKey = "resumes/user123/queue456-original-1234567890.tex";
+    const customizedKey = "resumes/user123/queue456-customized-1234567890.tex";
+
+    expect(originalKey).toContain("-original-");
+    expect(customizedKey).toContain("-customized-");
+    expect(originalKey).not.toEqual(customizedKey);
+  });
+
+  it("should handle LaTeX content preservation", () => {
+    const latexContent = "\\documentclass[11pt]{article}\n\\begin{document}\n\\section{Experience}\nSenior Engineer\n\\end{document}";
+    const preserved = latexContent.includes("\\documentclass") && latexContent.includes("\\end{document}");
+
+    expect(preserved).toBe(true);
+  });
+});

--- a/apps/web/src/lib/r2/resume-storage.ts
+++ b/apps/web/src/lib/r2/resume-storage.ts
@@ -1,0 +1,95 @@
+import { S3Client, GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+type R2Body = {
+  transformToString?: () => Promise<string>;
+};
+
+let r2Client: S3Client | null = null;
+
+function getR2Client(): S3Client {
+  if (r2Client) return r2Client;
+
+  const endpoint = process.env.R2_ENDPOINT_URL;
+  const accessKeyId = process.env.R2_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
+
+  if (!endpoint || !accessKeyId || !secretAccessKey) {
+    throw new Error("R2 credentials are not fully configured");
+  }
+
+  r2Client = new S3Client({
+    region: "auto",
+    endpoint,
+    credentials: { accessKeyId, secretAccessKey },
+  });
+
+  return r2Client;
+}
+
+function getR2Bucket(): string {
+  const bucket = process.env.R2_BUCKET;
+  if (!bucket) throw new Error("R2_BUCKET is not set");
+  return bucket;
+}
+
+export async function getResumeFromR2(key: string): Promise<string | null> {
+  try {
+    const response = await getR2Client().send(
+      new GetObjectCommand({
+        Bucket: getR2Bucket(),
+        Key: key,
+      }),
+    );
+
+    if (!response.Body) return null;
+
+    const reader = response.Body as R2Body;
+    if (typeof reader.transformToString === "function") {
+      return await reader.transformToString();
+    }
+
+    const chunks: Uint8Array[] = [];
+
+    const maybeAsyncReader = reader as R2Body & Partial<AsyncIterable<Uint8Array | Buffer | string>>;
+    if (typeof maybeAsyncReader[Symbol.asyncIterator] === "function") {
+      for await (const chunk of maybeAsyncReader as AsyncIterable<Uint8Array | Buffer | string>) {
+        chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : new Uint8Array(chunk));
+      }
+    }
+
+    const buffer = Buffer.concat(chunks);
+    return buffer.toString("utf-8");
+  } catch {
+    return null;
+  }
+}
+
+export async function saveResumeToR2(
+  key: string,
+  content: string,
+  contentType: string = "text/plain",
+): Promise<boolean> {
+  try {
+    await getR2Client().send(
+      new PutObjectCommand({
+        Bucket: getR2Bucket(),
+        Key: key,
+        Body: content,
+        ContentType: contentType,
+      }),
+    );
+    return true;
+  } catch (err) {
+    console.error("Failed to save resume to R2:", err);
+    return false;
+  }
+}
+
+export function buildResumeKey(
+  userId: string,
+  queueId: string,
+  type: "original" | "customized",
+): string {
+  const timestamp = Date.now();
+  return `resumes/${userId}/${queueId}-${type}-${timestamp}.tex`;
+}


### PR DESCRIPTION
## Summary

Salvages the useful customization-history work from stale PRs #4 and #5 onto current main.

- adds resume_customization_history plus user_resume customization metadata
- saves accepted resume customizations into history with ownership checks
- adds the CustomizationHistoryPanel to the queue page
- includes focused unit tests and the queue-page integration E2E spec
- fixes small existing lint issues that would block CI on the replacement PR

## Verification

- pnpm install --frozen-lockfile
- pnpm --filter @jseek/mcp-server build
- pnpm lint
- pnpm exec tsc --noEmit
- pnpm test: 37 files / 246 tests passed
- git diff --check

## Note

pnpm build was attempted twice. It reached Next.js "Creating an optimized production build ..." and produced no further output for several minutes, so I stopped the process rather than leave it running. Lint, TypeScript, and unit tests are clean.